### PR TITLE
refactor: 이미지 최적화 

### DIFF
--- a/src/pages/Makers.jsx
+++ b/src/pages/Makers.jsx
@@ -27,7 +27,7 @@ const Makers = () => {
               <div style={{ width: "100%" }}>
                 <AnimatedContainer key={index} index={index}>
                   <ProfileContainer>
-                    <Img src={item.img} alt="profileimg" />
+                    <Img src={item.img} alt="profileimg" loading="lazy" />
                     <BoxContainer>
                       <ProfileNameText>
                         {item.name} | {item.part}

--- a/src/pages/Project.jsx
+++ b/src/pages/Project.jsx
@@ -10,7 +10,7 @@ const ProjectCard = ({ project, onClick }) => {
 
   return (
     <Card onClick={() => onClick(project)}>
-      {bgImg ? <CardImage src={bgImg} alt={title} /> : <CardImage />}
+      {bgImg ? <CardImage src={bgImg} alt={title} loading="lazy"/> : <CardImage loading="lazy"/>}
       <CardContent>
         <Detail>
           자세히 보기


### PR DESCRIPTION
이미지 로딩 성능 개선을 위해, Makers.jsx와 Project.jsx 페이지의 이미지들에 Lazy Loading을 적용했습니다.

**1. Project.jsx** 
프로젝트 카드 이미지
```jsx
 {bgImg ? <CardImage src={bgImg} alt={title} loading="lazy" /> : <CardImage loading="lazy" />}
```

**2. Makers.jsx** 
메이커스 프로필 이미지
```jsx
<Img src={item.img} alt="profileimg" loading="lazy" />
```

<br/>

우선 간단한 lazy loading만 우선 적용하였는데, 페이지 진입 시에 화면에 보이지 않는 이미지들은 스크롤할 때까지 로딩되지 않도록 처리하여 한 번에 로딩되는 이미지 수를 줄여 좀 더 빠르게 확인할 수 있도록 했습니다. 
더 세밀한 최적화 방식을 도입할지도 고민해보았는데, lazy loading만 적용해도 체감 성능이 꽤 크게 개선되는 것을 로컬 상에서 체감할 수 있었기 때문에 이 수준까지만 적용해두었습니다!

추후 페이지 전체를 다같이 점검하면서 더 정밀한 이미지 최적화가 필요하다고 판단되면, 그때 포맷 변경이나 압축, 프리패칭 같은 방식들도 함께 고려해보면 좋을 것 같습니다.